### PR TITLE
On bouge de pep8 à pycodestyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 install:
 - pip install -r requirements.txt
 script:
-- pep8 --exclude=tofdata .
+- pycodestyle --exclude=tofdata .
 - nosetests
 deploy:
   provider: openshift

--- a/irc.py
+++ b/irc.py
@@ -54,11 +54,8 @@ class Bot(asynchat.async_chat):
         self.sending.acquire()
         asynchat.async_chat.initiate_send(self)
         self.sending.release()
-    # def push(self, *args, **kargs):
-    #     asynchat.async_chat.push(self, *args, **kargs)
 
     def __write(self, args, text=None):
-        # print 'PUSH: %r %r %r' % (self, args, text)
         try:
             if text is not None:
                 # 510 because CR and LF count too, as nyuszika7h points out
@@ -184,26 +181,6 @@ class Bot(asynchat.async_chat):
     def notice(self, dest, text):
         self.write(('NOTICE', dest), text)
 
-    def error(self, origin):
-        try:
-            import traceback
-            trace = traceback.format_exc()
-            print trace
-            lines = list(reversed(trace.splitlines()))
-
-            report = [lines[0].strip()]
-            for line in lines:
-                line = line.strip()
-                if line.startswith('File "/'):
-                    report.append(line[0].lower() + line[1:])
-                    break
-            else:
-                report.append('source unknown')
-
-            self.msg(origin.sender, report[0] + ' (' + report[1] + ')')
-        except:
-            self.msg(origin.sender, "Got an error.")
-
 
 class TestBot(Bot):
     def f_ping(self, origin, match, args):
@@ -218,9 +195,8 @@ class TestBot(Bot):
 
 
 def main():
-    # bot = TestBot('testbot', ['#d8uv.com'])
-    # bot.run('irc.freenode.net')
     print __doc__
+
 
 if __name__ == "__main__":
     main()

--- a/plugins/classifier.py
+++ b/plugins/classifier.py
@@ -109,9 +109,9 @@ class SqliteBackend(StorageBackend):
                 WHERE class=? AND feature=?
                 """, (c, f)
                 )
-        l = list(cursor)
-        if l:
-            res = int(l[0][0])
+        entries = list(cursor)
+        if entries:
+            res = int(entries[0][0])
         cursor.close()
         return res
 

--- a/plugins/dassin.py
+++ b/plugins/dassin.py
@@ -41,7 +41,7 @@ class PluginDassin(Plugin):
                         best = song[i + 1]
                         minDist = dist
                     i += 1
-            except:
+            except IndexError:
                 pass
 
         if len(best) > 3 and minDist < (len(searched) / 3):

--- a/plugins/euler.py
+++ b/plugins/euler.py
@@ -46,7 +46,7 @@ class PluginEuler(Plugin):
                 data = response.text.split(',')
                 if(len(data) >= 4):
                     scores[nick] = data[3]
-        except:
+        except requests.ConnectionError:
             pass
         return scores
 

--- a/plugins/expand.py
+++ b/plugins/expand.py
@@ -52,12 +52,12 @@ class PluginExpand(Plugin):
             try:
                 exp = urlExpand(url)
                 self.say(exp)
-            except:
+            except (requests.exceptions.RequestException, requests):
                 pass
 
         if is_video(url):
             try:
                 t = getTitle(url)
                 self.say(t)
-            except:
+            except (requests.exceptions.RequestException, AttributeError):
                 pass

--- a/plugins/risoli.py
+++ b/plugins/risoli.py
@@ -68,7 +68,7 @@ class PluginRisoli(Plugin):
         self._register_leave(nick)
 
     def handle_msg(self, msg_text, chan, nick):
-        m = re.match('%s: (\d+)' % re.escape(self.bot.nick), msg_text)
+        m = re.match('%s: (\\d+)' % re.escape(self.bot.nick), msg_text)
         if not m:
             return
         if not self._game:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ unidecode
 mock
 nose
 coverage
-pep8
+pycodestyle

--- a/t.py
+++ b/t.py
@@ -4,8 +4,8 @@ from testbot import TestTofbot, print_resp
 class Origin:
     pass
 
-chan = '#test'
 
+chan = '#test'
 origin = Origin()
 origin.sender = 'TestTofbot'
 
@@ -29,8 +29,8 @@ def cb_lines(n):
 def cb_error(msg):
     return cb_lines(0)
 
-b = TestTofbot('ohohOHoh_bot', 'Le tof', chan, origin)
 
+b = TestTofbot('ohohOHoh_bot', 'Le tof', chan, origin)
 b.send("End of /MOTD command.", cb=cb_error)
 b.send("test", cb=cb_error)
 b.send("!help", cb=cb_lines(4))

--- a/tests/common.py
+++ b/tests/common.py
@@ -96,8 +96,8 @@ class TofbotTestCase(unittest.TestCase):
             outp = [outp]
 
         def wrapper(f):
-            l = bot_action(self.bot, lambda: f())
-            self.assertEqual(l, outp)
+            line = bot_action(self.bot, lambda: f())
+            self.assertEqual(line, outp)
 
         return wrapper
 
@@ -105,27 +105,27 @@ class TofbotTestCase(unittest.TestCase):
         """
         Test that a given input produces a given output.
         """
-        l = bot_input(self.bot, inp)
+        line = bot_input(self.bot, inp)
         if isinstance(outp, str):
             outp = [outp]
-        self.assertEqual(l, outp)
+        self.assertEqual(line, outp)
 
     def assertOutputContains(self, inp, outp):
         """
         Test that a given input produces a given output (among others)
         """
-        l = bot_input(self.bot, inp)
+        line = bot_input(self.bot, inp)
         if isinstance(outp, str):
             outp = [outp]
         for o in outp:
-            self.assertIn(o, l)
+            self.assertIn(o, line)
 
     def assertOutputLength(self, msg, n):
         """
         Checks that when fed with msg, the bot's answer has length n.
         """
-        l = bot_input(self.bot, msg)
-        self.assertEqual(len(l), n)
+        line = bot_input(self.bot, msg)
+        self.assertEqual(len(line), n)
 
     def assertNoOutput(self, msg):
         self.assertOutput(msg, [])

--- a/tests/test_euler.py
+++ b/tests/test_euler.py
@@ -33,5 +33,5 @@ class TestEuler(TofbotTestCase):
 
         self.assertOutput("!euler", "leonhard : Solved 10")
         set_score(15)
-        l = bot_action(self.bot, event.fire)
-        self.assertEqual(l, ["leonhard : Solved 10 -> Solved 15"])
+        line = bot_action(self.bot, event.fire)
+        self.assertEqual(line, ["leonhard : Solved 10 -> Solved 15"])

--- a/tests/test_jokes.py
+++ b/tests/test_jokes.py
@@ -8,8 +8,8 @@ class TestEuler(TofbotTestCase):
         (event_k, event) = self._find_event(TofadeEvent)
 
         self.bot.send('!set autoTofadeThreshold 0')
-        l = bot_action(self.bot, event.fire)
-        self.assertEqual(len(l), 1)
+        line = bot_action(self.bot, event.fire)
+        self.assertEqual(len(line), 1)
         self.bot.send('!set autoTofadeThreshold 9000')
 
     def test_jokes_misc(self):

--- a/tests/test_lol.py
+++ b/tests/test_lol.py
@@ -45,5 +45,5 @@ class TestLol(TofbotTestCase):
 
     def test_lol_kick(self):
         self.bot.send('lol', origin='michel')
-        l = bot_kick(self.bot)
-        self.assertIn('Au passage, michel est un sacré Kevin', l)
+        line = bot_kick(self.bot)
+        self.assertIn('Au passage, michel est un sacré Kevin', line)

--- a/tests/testbot.py
+++ b/tests/testbot.py
@@ -15,12 +15,12 @@ class TestCase(TofbotTestCase):
                           "autoTofadeThreshold = 9000")
 
     def test_kick(self):
-        l = bot_kick(self.bot)
-        self.assertEqual(l, ["respawn, LOL"])
+        line = bot_kick(self.bot)
+        self.assertEqual(line, ["respawn, LOL"])
 
     def test_kick_reason(self):
-        l = bot_kick(self.bot, "tais toi")
-        self.assertEqual(l, ["comment ça, tais toi ?"])
+        line = bot_kick(self.bot, "tais toi")
+        self.assertEqual(line, ["comment ça, tais toi ?"])
 
     def test_dassin(self):
         self.assertOutput("tu sais",

--- a/toflib.py
+++ b/toflib.py
@@ -181,6 +181,7 @@ class Cron:
     def schedule(self, ev):
         self.events.append(ev)
 
+
 # http://daringfireball.net/2010/07/improved_regex_for_matching_urls
 # Public Domain
 RE_URL = re.compile(


### PR DESCRIPTION
pep8 nous avertit qu'il sera bientôt déprécié au profit de pycodestyle.
Voici donc un atome de code pour assurer une transition sereine. J'ai
corrigé les avertissements que pycodestyle levaient et que pep8 ne lève
pas.

J'ai viré au passage le code mort de la fonction "error" dans irc.py.